### PR TITLE
mobile-broadband-provider-info: Add bbappend to specify branch in SRC_URI

### DIFF
--- a/recipes-poky-compat/mobile-broadband-provider-info/mobile-broadband-provider-info_%.bbappend
+++ b/recipes-poky-compat/mobile-broadband-provider-info/mobile-broadband-provider-info_%.bbappend
@@ -1,0 +1,6 @@
+SRC_URI_remove = " \
+    git://gitlab.gnome.org/GNOME/mobile-broadband-provider-info.git;protocol=https \
+"
+SRC_URI_prepend = " \
+    git://gitlab.gnome.org/GNOME/mobile-broadband-provider-info.git;protocol=https;branch=main \
+"


### PR DESCRIPTION
# Purpose of pull request

In the case of [1], do_fetch of mobile-broadband-provider-info of Poky fails.
This is because default branch name of mobile-broadband-provider-info's git repository has changed to "main".

To fix the above issue, we add a bbappend file replacing the SRC_URI.

Referred commits in the Poky master branch:
- ddcf16d1f7 meta: Add explict branch to git SRC_URIs
- e4795393c4 mobile-broadband-provider-info: upgrade 20210805 -> 20220315

The meta-debian depends on Poky, but its warrior branch is not maintained.
There may potentially be other cases where unupdated Poky recipes cause build errors similar to this one, and we expect to see more in the future. So we introduce the "recipes-poky-compat" directory as a place to fix these issue.

[1]:
Add the following to conf/local.conf:
```
DISTRO = "deby"
MACHINE = "qemuarm64"
IMAGE_INSTALL_append = "connman"
```
and run `bitbake core-image-minimal`, the following error:
```
ERROR: mobile-broadband-provider-info-1_20190116-r0 do_fetch: Fetcher failure: Unable to find revision c7def60ba50d9cc30a90f69f89d7e82243501e86 in branch master even from upstream
ERROR: mobile-broadband-provider-info-1_20190116-r0 do_fetch: Fetcher failure for URL: 'git://gitlab.gnome.org/GNOME/mobile-broadband-provider-info.git;protocol=https'. Unable to fetch URL from any source. 
```

# Test
## How to test
Add following line into conf/local.conf.
```
DISTRO = "deby"
MACHINE = "qemuarm64"
IMAGE_INSTALL_append = "connman"
```
And then run following command.
```
$ bitbake core-image-minimal
```

## Test result
Build succeeded.
```
build$ bitbake core-image-minimal
Parsing recipes: 100% |#################################################################################################| Time: 0:00:04
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 74 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "add-mobile-broadband-provider-info-bbappend:c173ed84aabeded7ec32e9d29808627240aa1ff3"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 1102 Found 0 Missed 1102 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3656 tasks of which 5 didn't need to be rerun and all succeeded.
```