### PR TITLE
classes: Add kernel-cve-check.bbclass

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -167,6 +167,14 @@ def get_patches_cves(d):
     return patched_cves
 
 def check_cves(d, patched_cves):
+    # Original check_cves() in meta-debian.
+    patched, unpatched = check_cves_base(d, patched_cves)
+    return (patched, unpatched)
+
+# check_cves_base() is the actual processing of check_cves(), and can be used
+# like a superclass method call from other class.
+def check_cves_base(d, patched_cves):
+
     """
     Connect to the NVD database and find unpatched cves.
     """

--- a/classes/gitpkgv.bbclass
+++ b/classes/gitpkgv.bbclass
@@ -44,6 +44,11 @@ GITPKGVTAG = "${@get_git_pkgv(d, True)}"
 # groups will be concatenated to yield the final version.
 GITPKGV_TAG_REGEXP ??= "v(\d.*)"
 
+# This variable specifies options to git-describe command used to getting the tag name.
+# The default is `--exact-match`.
+# To get the closest tag name from a specified hash, specify `--abbrev=0`.
+GITPKGV_TAG_OPTION ??= "--exact-match"
+
 def gitpkgv_drop_tag_prefix(d, version):
     import re
 
@@ -108,8 +113,9 @@ def get_git_pkgv(d, use_tags):
 
                 if use_tags:
                     try:
+                        vars['opt'] = d.getVar('GITPKGV_TAG_OPTION')
                         output = bb.fetch2.runfetchcmd(
-                            "git --git-dir=%(repodir)s describe %(rev)s --tags --exact-match 2>/dev/null"
+                            "git --git-dir=%(repodir)s describe %(rev)s --tags %(opt)s 2>/dev/null"
                             % vars, d, quiet=True).strip()
                         ver = gitpkgv_drop_tag_prefix(d, output)
                     except Exception:

--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -1,0 +1,295 @@
+#
+# kernel-cve-check.bbclass
+#
+# This class checks fixed CVEs in kernel by using cip-kernel-sec
+# and adds them to the CVE_CHECK_WHITELIST before the cve_check runs.
+#
+# This class reads cip version from 'LINUX_CIP_VERSION' variable.
+# Set the version of cip kernel to be used in the variable.
+#
+# Example:
+#   LINUX_CIP_VERSION = 'v4.19.165-cip41'
+#
+# In order to use this class inherit this class in the local.conf
+# and run cve_check task.
+
+inherit cve-check
+
+KERNEL_CVE_CHECK_DIR ?= "${CVE_CHECK_DB_DIR}/KERNEL"
+
+# Consider ignore information.
+# If value is "0", add CVEs that are registered as negligible to whitelist.
+KERNEL_CVE_CHECK_INCLUDE_IGNORE ?= "1"
+
+# Add ignore information to cve manifest.
+KERNEL_CVE_CHECK_SHOW_IGNORE_INFO ?= "0"
+
+# Remote branch name. bitbake detects it from kernel-src by default.
+KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO ??= ""
+KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT ??= "1"
+
+# It requires an initial value to ignore kernel cve check if PN is not kernel
+KERNEL_PN = "not_kernel"
+KERNEL_CVE_CHECK_TASK_ORDER = ""
+
+python() {
+    if d.getVar("PN") == d.getVar("PREFERRED_PROVIDER_virtual/kernel"):
+        d.setVar('KERNEL_PN', d.getVar('PN'))
+        d.setVar('KERNEL_CVE_CHECK_TASK_ORDER', '{}:do_unpack {}:do_prepare_recipe_sysroot'.format(d.getVar('KERNEL_PN'), d.getVar('KERNEL_PN')))
+}
+
+###############################################################################
+# override check_cves() in cve-check.bbclass
+###############################################################################
+def check_cves(d, patched_cves):
+    # Overrided check_cves() by kernel-cve-check.bbclass
+    patched, unpatched = kernel_check_cves_base(d, patched_cves)
+    return (patched, unpatched)
+
+def kernel_check_cves_base(d, patched_cves):
+    # check_cves_base() is the actual processing of check_cves() in
+    # cve-check.bbclass, and is used like a superclass method call.
+    patched, unpatched = check_cves_base(d, patched_cves)
+
+    if d.getVar("PN") == d.getVar("KERNEL_PN"):
+        cip_kernel_sec_affected_cves = d.getVar("CIP_KERNEL_SEC_AFFECTED_CVES")
+        if len(cip_kernel_sec_affected_cves) > 0:
+            tmp = cip_kernel_sec_affected_cves.split(" ")
+            for cve in tmp:
+                # Do not override poky's cve-check result when cve is in patched list.
+                if not cve in unpatched and not cve in patched:
+                    unpatched.append(cve)
+
+            unpatched = sorted(unpatched)
+
+        cip_kernel_sec_fixed_cves = d.getVar("CIP_KERNEL_SEC_FIXED_CVES")
+        if len(cip_kernel_sec_fixed_cves) > 0:
+            tmp = cip_kernel_sec_fixed_cves.split(" ")
+            for cve in tmp:
+                if cve in unpatched:
+                    # in case poky's cve-check thought this cve is unpatched but cip-kernel-sec said it's fixed
+                    idx = unpatched.index(cve)
+                    unpatched.pop(idx)
+                if not cve in patched:
+                    patched.append(cve)
+
+            patched = sorted(patched)
+
+    return (patched, unpatched)
+
+###############################################################################
+# update_cip_kernel_sec
+###############################################################################
+
+def remove_remote(workdir):
+    """
+    Remove needless remotes from remotes.yml.
+    """
+    import yaml
+
+    remotes_path = os.path.join(workdir, "remotes.yml")
+
+    with open(remotes_path) as f:
+        content = yaml.safe_load(f)
+
+    with open(remotes_path, "w") as f:
+        yaml.dump({"cip": content["cip"]}, f, default_flow_style=False)
+
+python update_cip_kernel_sec () {
+    """
+    Update cip-kernel-sec repository.
+    """
+    from bb.fetch2 import runfetchcmd
+
+    kernel_cve_check_dir = d.getVar("KERNEL_CVE_CHECK_DIR")
+    cip_kernel_sec_path = os.path.join(kernel_cve_check_dir, "cip-kernel-sec")
+    git_uri = "https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec.git"
+
+    if not os.path.isdir(kernel_cve_check_dir):
+        os.mkdir(kernel_cve_check_dir)
+
+    if not os.path.isdir(cip_kernel_sec_path):
+        # first run
+        runfetchcmd("git clone %s cip-kernel-sec" % git_uri, d,  workdir=kernel_cve_check_dir)
+        remove_remote(os.path.join(cip_kernel_sec_path, "conf"))
+        runfetchcmd("git update-index --skip-worktree conf/remotes.yml", d, workdir=cip_kernel_sec_path)
+    else:
+        runfetchcmd("git pull", d, workdir=cip_kernel_sec_path)
+}
+
+do_populate_cve_db[postfuncs] += "update_cip_kernel_sec"
+
+###############################################################################
+# kernel_cve_check
+###############################################################################
+
+def get_issue_list(cip_kernel_sec_path):
+    """
+    Get issue list registered to cip-kernel-sec.
+    """
+    import glob
+    glob_param = cip_kernel_sec_path + "/issues/CVE-*.yml"
+
+    return [os.path.basename(name)[:-4] for name in glob.glob(glob_param)]
+
+python kernel_cve_check () {
+    """
+    Check cves by cip-kernel-sec
+    """
+    from bb.fetch2 import runfetchcmd
+    import requests
+    import bb.process
+    import yaml
+    import os
+    import tempfile
+
+    kernel_path = d.getVar("S")
+    linux_cip_ver = d.getVar("LINUX_CIP_VERSION")
+    kernel_cve_check_dir = d.getVar("KERNEL_CVE_CHECK_DIR")
+    cip_kernel_sec_path = os.path.join(kernel_cve_check_dir, "cip-kernel-sec")
+    include_ignore = d.getVar("KERNEL_CVE_CHECK_INCLUDE_IGNORE")
+    remote_repo_name = d.getVar("KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO")
+    remote_repo_autodetect = d.getVar("KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT")
+
+    if linux_cip_ver is None:
+        bb.error("LINUX_CIP_VERSION is not set. Please set version")
+        return
+
+    opt_ignore = "--include-ignored" if include_ignore == "1" else ""
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        output_filename = f.name
+
+    # Try to get remote name from kernel repository
+    if not remote_repo_name and remote_repo_autodetect == "1":
+        try:
+            bb.debug(2, "No remote name is defined and KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT is set. bitbake detects remote name from kernel-src")
+            stdout, _ = bb.process.run('git remote', cwd=kernel_path, shell=True)
+            remote_repo_name = stdout.splitlines()[0]
+        except bb.process.ExecutionError as e:
+            bb.warn("Failed to detect remote name. bitbake assumes that remote is 'origin'. Please consider setting KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO")
+
+    cert_path = requests.certs.where()
+    cmdenv = "PYTHONPATH='%s' SSL_CERT_FILE='%s'" % (':'.join(sys.path), cert_path)
+    script = "python3 scripts/report_affected.py"
+    cmdopt = "%s --include-fixed --output-format=yaml --output-filename=%s --remote-name cip:%s --git-repo" % (opt_ignore, output_filename, remote_repo_name)
+    params = ' '.join([kernel_path, linux_cip_ver])
+    cmd = ' '.join([cmdenv, script, cmdopt, params])
+    bb.debug(2, "Run report_affected.py, cmd: %s" % cmd)
+    try:
+        runfetchcmd(cmd, d, workdir=cip_kernel_sec_path)
+    except bb.fetch2.FetchError as e:
+        bb.warn("Failed to run report_affected.py: %s" % (e))
+
+    fixed_cves = []
+    tmp_affected_cves = []
+    with open(output_filename) as f:
+        yaml_data = yaml.safe_load(f)
+        if yaml_data is not None:
+            k = list(yaml_data)[0]
+
+            # We don't need ignored data because CVEs in ignore section is not affected to this kernel version.
+            tmp_affected_cves.extend(yaml_data[k]["affected"])
+            fixed_cves = yaml_data[k]["fixed"]
+
+    os.unlink(output_filename)
+
+    whitelist = []
+    for cve in get_issue_list(cip_kernel_sec_path):
+        if cve not in tmp_affected_cves:
+            whitelist.append(cve)
+    whitelist = sorted(whitelist)
+
+    bb.debug(2, "Whitelisted by cip-kernel-sec:\n    %s" % "\n    ".join(whitelist))
+    d.appendVar("CVE_CHECK_WHITELIST", ' ' + ' '.join(whitelist))
+
+    safelist_str = d.getVar("CVE_CHECK_WHITELIST")
+    safelist = safelist_str.split(" ")
+
+    affected_cves = []
+    for cve in tmp_affected_cves:
+        if not cve in safelist:
+            affected_cves.append(cve)
+        else:
+            fixed_cves.append(cve)
+
+    d.setVar("CIP_KERNEL_SEC_AFFECTED_CVES", " ".join(affected_cves))
+    d.setVar("CIP_KERNEL_SEC_FIXED_CVES", " ".join(fixed_cves))
+}
+
+do_cve_check[prefuncs] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), 'kernel_cve_check', '', d)}"
+do_cve_check[depends] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), d.getVar('KERNEL_CVE_CHECK_TASK_ORDER'), '', d)}"
+
+###############################################################################
+# write_ignore_info
+###############################################################################
+
+def get_ignore_info(cip_kernel_sec_path, cve_id, d):
+    """
+    Get ignore reason for the cve_id.
+    """
+    import sys
+
+    sys.path.append(cip_kernel_sec_path + "/scripts")
+    import kernel_sec.issue
+
+    cwd = os.getcwd()
+    os.chdir(cip_kernel_sec_path)
+    issue = kernel_sec.issue.load(cve_id)
+    os.chdir(cwd)
+
+    ignore = issue.get('ignore', {})
+    for branch_name in ignore:
+        if branch_name == "all" or branch_name == "cip/4.19":
+            return ignore[branch_name].replace('\n', ' ')
+    return None
+
+def insert_ignore_info(file_name, d):
+    """
+    Insert IGNORE INFO attribute.
+    """
+    if not os.path.isfile(file_name):
+        bb.error("%s is not found." % file_name)
+        return
+
+    kernel_cve_check_dir =d.getVar("KERNEL_CVE_CHECK_DIR")
+    cip_kernel_sec_path = os.path.join(kernel_cve_check_dir, "cip-kernel-sec")
+    issue_list = get_issue_list(cip_kernel_sec_path)
+
+    with open(file_name, "r") as f:
+        content = f.readlines()
+
+    for index,line in enumerate(content):
+        ignore_info = None
+        if line.startswith("PACKAGE NAME:"):
+            pkg_name = line.split()[2]
+        if line.startswith("CVE:") and pkg_name == d.getVar('KERNEL_PN'):
+            cve_id = line.split()[1]
+            if cve_id in issue_list:
+                ignore_info = get_ignore_info(cip_kernel_sec_path, cve_id, d)
+                if ignore_info:
+                    content.insert(index+6, "IGNORE INFO: %s\n" % ignore_info)
+
+    with open(file_name, "w") as f:
+        for line in content:
+            f.write(line)
+
+python write_ignore_info () {
+    """
+    Write ignore information to CVE manifest
+    """
+
+    cve_file = d.getVar("CVE_CHECK_LOG")
+
+    insert_ignore_info(cve_file, d)
+
+    if d.getVar("CVE_CHECK_COPY_FILES") == "1":
+        cve_dir = d.getVar("CVE_CHECK_DIR")
+        deploy_file = os.path.join(cve_dir, d.getVar("PN"))
+        insert_ignore_info(deploy_file, d)
+
+    if d.getVar("CVE_CHECK_CREATE_MANIFEST") == "1":
+        tmp_file = d.getVar("CVE_CHECK_TMP_FILE")
+        insert_ignore_info(tmp_file, d)
+}
+
+do_cve_check[postfuncs] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), 'write_ignore_info', '', d) if d.getVar('KERNEL_CVE_CHECK_SHOW_IGNORE_INFO') == '1' else ''}"

--- a/classes/linux-src.bbclass
+++ b/classes/linux-src.bbclass
@@ -40,6 +40,11 @@ PV = "${LINUX_VERSION}+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 # use GITPKGVTAG for cve-check
+GITPKGV_TAG_REGEXP = "(.*)"
+GITPKGV_TAG_OPTION = "--abbrev=0"
 inherit gitpkgv
-do_cve_check[depends] += "linux-base:do_fetch"
-CVE_VERSION ??= "${@d.getVar('GITPKGVTAG').split('-')[0]}"
+do_cve_check[depends] += "virtual/kernel:do_fetch"
+CVE_VERSION ??= "${@oe.utils.conditional('LINUX_CIP_VERSION', '', d.getVar('PV'), d.getVar('LINUX_CIP_VERSION').split('-')[0].replace('v', ''), d)}"
+
+# If use cip_kernel, for kernel-cve-check
+LINUX_CIP_VERSION ??= "${@oe.utils.str_filter(r'(v\d.*-cip\d.*)', d.getVar('GITPKGVTAG'), d)}"

--- a/doc/7.cve-check.md
+++ b/doc/7.cve-check.md
@@ -1,8 +1,15 @@
-# CVE Check feature
+# CVE Check feature for Debian packages
 
 The CVE check feature is based on Poky's CVE check functionality and uses NVD vulnerability information. However, the fixed versions listed in NVD vulnerability information may not match Debian package versions. As a result, relying solely on NVD vulnerability information could lead to Debian packages that have already been patched being mistakenly identified as unpatched. To address this issue, the CVE check feature in meta-debian utilizes Debian vulnerability information to eliminate false positives.
 
-# Variable
+## Usage
+
+Add the following line to local.conf to enable debian-cve-check:
+```
+INHERIT += " cve-check debian-cve-check"
+```
+
+## Variable
 
 - DEBIAN\_SECRUTY\_TRACKER\_JSON\_URL
 
@@ -22,3 +29,14 @@ Replace URL:
 DEBIAN_SECRUTY_TRACKER_JSON_URL = "http://localhost:8000/dst.json"
 ```
 
+
+# CVE Check feature for Kernel
+
+The CVE check feature for Kernel is also based on Poky's CVE checker and uses NVD vulnerability information. However, In NVD vulnerability information, may not be detected correctly if the score is 0 or CPE is unregistered. To address this issue, the CVE check feature for Kernel in meta-debian utilizes cip-kernel-sec tracking information to eliminate false positives, since the meta-debian kernel source code uses cip-kernel.
+
+## Usage
+
+Add the following line to local.conf to enable kernel-cve-check:
+```
+INHERIT += " cve-check kernel-cve-check"
+```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,10 @@ RUN apt-get update && \
 	python3-pexpect xz-utils debianutils iputils-ping file locales \
 	openssh-client python3-debian
 
+# for kernel-cve-check.bbclass
+RUN apt-get install -y --no-install-recommends \
+	python3-yaml python3-html5lib python3-requests
+
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 RUN useradd -d $HOME -U -m -s /bin/bash -u $UID $USER
 RUN usermod -a -G sudo $USER


### PR DESCRIPTION
# Purpose of pull request

cve-check may not correctly detect kernel vulnerabilities if the NVD information score is 0 or if CPE is not set.

In meta-debian, Kernel source code uses cip-kernel. The cip-project[1] has a cip-kernel-sec[2] that tracks the status of security problems identified by CVE IDs.

So, add kernel-cve-check.bbclass, which complements the CVE check using information from cip-kernel-sec.

Description of kernel-cve-check.bbclass:
  The kernel-cve-check.bbclass uses the LINUX_CIP_VERSION variable.
  Add LINUX_CIP_VERSION default value setting to linux-src.bbclass, which
  defined Kernel SRCREV. This value sets the tag name closest to Kernel SRCREV
  of the cip-kernel.

  The kernel-cve-check.bbclass overrides check_cves() function and completes
  the CVE check result with the cip-kernel-sec information after calling the
  original processing check_cves_base() function.
  The check_cves() function is called in do_cve_check task of cve-check.bbclass.

And the following improvements for add kernel-cve-check.bbclass:
- In doc/7.cve-check.md, added explanation for kernel-cve-check and improved debian-cve-check chapter accordingly
- In Dockerfile, add package installation of Python3 modules used by kernel-cve-check.bbclass
- In cve-check.bbclass, allow overriding the check_cves() function
- In gtpkgv.bbclass, add GITPKGV_TAG_OPTION to allow changing the option specify to `git describe`, for get closest tag name
- In linux-src.bbclass:
  - Improve CVE_VERSION default value, because tag names cannot be retrieved if the hash has no tags set (HEAD does not always have a tag set)
  - do_cve_check[depend] changed to `virtual/kernel:do_fetch` instead of `linux-base:do_fetch`, considering the possibility of Kernel recipe name changes in upper layers

[1] https://www.cip-project.org/
[2] https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec

# Test
## How to test

1. Start the Docker build environment
   ```
   $ cd poky/meta-debian/docker
   $ make start
   ```

2. Setup the build environment
   ```
   $ export TEMPLATECONF=meta-debian/conf
   $ source ./poky/oe-init-build-env
   ```

3. Setting to local.conf

   Add following line into conf/local.conf.
   ```
   DISTRO = "deby"
   MACHINE = "qemuarm64"
   INHERIT += " cve-check kernel-cve-check"
   ```

   Since this PR targets the kernel, for Debian packages follow doc/6.security-update.md to enable security updates.
   ```
   DEBIAN_SOURCE_ENABLED = "1"
   DEBIAN_SRC_FORCE_REGEN = "1"
   
   DEBIAN_SECURITY_UPDATE_ENABLED = "1"
   DEBIAN_SECURITY_UPDATE_MIRROR = "http://security.debian.org/debian-security/pool/updates"
   DEBIAN_ELTS_SECURITY_UPDATE_MIRROR = "http://deb.freexian.com/extended-lts/pool"
   ```

4. Check core-image-minimal build

   Comment out the INHERIT line added to local.conf.
   Run the following command to build core-image-minimal.
   ```
   $ bitbake core-image-minimal
   ```

5. Check bitbake variables

   Run the following command for check bitbake variables.
   ```
   $ bitbake -e linux-base -c cve_check | grep -e "LINUX_VERSION=" -e "CVE_VERSION=" -e "LINUX_CIP_VERSION=" -e "PV=" -e "PKGV=" -e "GITPKGVTAG="
    ```

   Check the variables before and after applying this PR.

6. Run CVE checks of kernel

   Run the following command for CVE checks of kernel.
   ```
   $ bitbake linux-base -c cve_check
   ```

   Compare CVE check results with and without "kernel-cve-check" in  INHERIT on local.conf.


# Test result
## Check core-image-minimal build

The build of core-image-minimal was successful.
```
deby@5f23f7b8bf21:~/build$ bitbake core-image-minimal
WARNING: debian security update repository is enabled
WARNING: debian ELTS security update repository is enabled
Checking Debian Release ... http://deb.freexian.com/extended-lts/dists/buster-lts/Release
Fetching Debian Sources.gz ... http://deb.freexian.com/extended-lts/dists/buster-lts/main/source/Sources.gz;md5sum=42c150792c4682d88d8f01185e0c7d69
Parsing Debian Sources.gz ...
WARNING: Source code for package "git" has been updated from "2.20.1-2+deb10u9" to "2.20.1-2+deb10u10"
WARNING: Source code for package "gnutls28" has been updated from "3.6.7-4+deb10u12" to "3.6.7-4+deb10u13"
WARNING: Source code for package "curl" has been updated from "7.64.0-4+deb10u10" to "7.64.0-4+deb10u12"
WARNING: Source code for package "sudo" has been updated from "1.8.27-1+deb10u6" to "1.8.27-1+deb10u7"
WARNING: Source code for package "suricata" has been updated from "4.1.2-2+deb10u2" to "4.1.2-2+deb10u3"
WARNING: Source code for package "python2.7" has been updated from "2.7.16-2+deb10u5" to "2.7.16-2+deb10u6"
WARNING: Source code for package "libxslt" has been updated from "1.1.32-2.2~deb10u2" to "1.1.32-2.2~deb10u3"
WARNING: Source code for package "glibc" has been updated from "2.28-10+deb10u4" to "2.28-10+deb10u5"
WARNING: Source code for package "tzdata" has been updated from "2024b-0+deb10u1" to "2025b-0+deb10u1"
WARNING: Source code for package "libxml2" has been updated from "2.9.4+dfsg1-7+deb10u10" to "2.9.4+dfsg1-7+deb10u11"
WARNING: Source code for package "python3.7" has been updated from "3.7.3-2+deb10u9" to "3.7.3-2+deb10u10"
WARNING: Source code for package "glib2.0" has been updated from "2.58.3-2+deb10u7" to "2.58.3-2+deb10u8"
WARNING: Source code for package "expat" has been updated from "2.2.6-2+deb10u8" to "2.2.6-2+deb10u9"
WARNING: Source code for package "u-boot" has been updated from "2019.01+dfsg-7" to "2019.01+dfsg-7+deb10u1"
Checking Debian Release ... http://security.debian.org/debian-security/dists/buster/updates/Release
Fetching Debian Sources.gz ... http://security.debian.org/debian-security/dists/buster/updates/main/source/Sources.gz;md5sum=e3bb28be0cf1fb769d3c63c037fc5bf8
Parsing Debian Sources.gz ...
Checking Debian Release ... http://ftp.debian.org/debian/dists/buster/Release
Fetching Debian Sources.gz ... http://ftp.debian.org/debian/dists/buster/main/source/Sources.gz;md5sum=60b1a2c60363095f2871f4a056e36980
Parsing Debian Sources.gz ...
Parsing recipes: 100% |#################################################################################################| Time: 0:00:04
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 74 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "add-kernel-cve-check:d1362a0624cbc3dd7706f4acf3ebb41e2d28b36d"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.9/x86_64-nativesdk-libc.tar.xz;sha256sum=d07916b95c419c81541a19c8ef0ed8cbd78ae18437ff28a4c8a60ef40518e423
Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 842 Found 0 Missed 842 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2965 tasks of which 5 didn't need to be rerun and all succeeded.

Summary: There were 16 WARNING messages shown.
```

## Check bitbake variables

Before applying this PR, CVE_VERSION was not set because the HEAD of the Kernel source code was not tagged.
After applying this PR, the tag closest to HEAD is obtained and CVE_VERSION and LINUX_CIP_VERSION are set correctly.

### After applying this PR

```
deby@5f23f7b8bf21:~/build$ bitbake -e linux-base -c cve_check | grep -e "LINUX_VERSION=" -e "CVE_VERSION=" -e "LINUX_CIP_VERSION=" -e "PV=" -e "PKGV=" -e "GITPKGVTAG="
CVE_VERSION="4.19.325"
EXTENDPKGV="4.19+gitAUTOINC+fbbced393b-r0"
GITPKGV="815727+fbbced3"
GITPKGVTAG="v4.19.325-cip121"
LINUX_CIP_VERSION="v4.19.325-cip121"
LINUX_VERSION="4.19"
PKGV="4.19+gitAUTOINC+fbbced393b"
PV="4.19+gitAUTOINC+fbbced393b"
SRCPV="AUTOINC+fbbced393b"
```

### Before applying this PR

```
deby@bd2f01026a6a:~/build$ bitbake -e linux-base -c cve_check | grep -e "LINUX_VERSION=" -e "CVE_VERSION=" -e "LINUX_CIP_VERSION=" -e "PV=" -e "PKGV=" -e "GITPKGVTAG="
CVE_VERSION="None"
EXTENDPKGV="4.19+gitAUTOINC+fbbced393b-r0"
GITPKGV="None"
GITPKGVTAG="None"
LINUX_VERSION="4.19"
PKGV="4.19+gitAUTOINC+fbbced393b"
PV="4.19+gitAUTOINC+fbbced393b"
SRCPV="AUTOINC+fbbced393b"
```

### For reference

here is the current commit history of cip-kernel:
```
deby@5f23f7b8bf21:~/build$ cd tmp/work-shared/qemuarm64/kernel-source/
deby@5f23f7b8bf21:~/build/tmp/work-shared/qemuarm64/kernel-source$ git branch
* linux-4.19.y-cip
  master
deby@5f23f7b8bf21:~/build/tmp/work-shared/qemuarm64/kernel-source$ git log --oneline --decorate | head
fbbced393b4a (HEAD -> linux-4.19.y-cip, origin/linux-4.19.y-cip) x86/bugs: fix backport error in "x86/bugs: Don't fill RSB on VMEXIT with eIBRS+retpoline"
3237eeb37d4b (tag: v4.19.325-cip121) CIP: Bump version suffix to -cip121 after merge from cip/linux-4.19.y-st tree
7e9e85988094 Merge branch 'linux-4.19.y-st' into linux-4.19.y-cip
e00abfb443ca (tag: v4.19-st5) Update localversion-st, tree is up-to-date with 5.4.293.
127e4ee2c5d9 x86/bugs: Don't fill RSB on VMEXIT with eIBRS+retpoline
0aa36fa45e3b clk: check for disabled clock-provider in of_clk_get_hw_from_clkspec()
cce15cb09dc4 PCI: Rename PCI_IRQ_LEGACY to PCI_IRQ_INTX
c4670503de99 MIPS: cm: Fix warning if MIPS_CM is disabled
16b2f6909ee0 comedi: jr3_pci: Fix synchronous deletion of timer
b74b73b1f551 scsi: pm80xx: Set phy_attached to zero when device is gone
```

## Run CVE checks of kernel
Save /home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+fbbced393b-r0/temp/cve.log as with-kernel-cve-check.log and without-kernel-cve-check.log respectively.
- [with-kernel-cve-check.log](https://github.com/user-attachments/files/21100935/with-kernel-cve-check.log)  
- [without-kernel-cve-check.log](https://github.com/user-attachments/files/21100939/without-kernel-cve-check.log)

Since the difference is large, it is converted with the conv.sh script.

conv.sh:
``` shell
#!/bin/bash

cvelist=$1
if [ "$#" -ne 1 ] || ! [ -f "$cvelist" ]; then
    echo "Usage: $0 <cve.log>"
    exit
fi
tmpfile="$1.tmp"
output="$1.output"

if [ -f $output ]; then
    rm "$output"
fi

pkg_name=""
pkg_version=""
cve_id=""
cve_status=""
while read line; do
    case "$line" in
    *:*)
        key=`echo "${line}" | cut -s -d: -f1`
        val=`echo "${line}" | cut -s -d: -f2`
        key=`echo -e $key`
        val=`echo -e $val`
        case "$key" in
        "PACKAGE NAME")
            pkg_name="$val"
            pkg_version=""
            cve_id=""
            cve_status=""
            ;;
        "PACKAGE VERSION")
            pkg_version="$val";;
        "CVE")
            if [ -z "${cve_id}" ]; then
                cve_id="$val"
            fi
            ;;
        "CVE STATUS")
            cve_status="$val";;
        "MORE INFORMATION")
            if [ -n "$cve_id" ]; then
                echo "$cve_id, $cve_status, $pkg_name, $pkg_version" >> $tmpfile
            fi
            ;;
        esac;;
    *)
    esac
done < $cvelist

cat $tmpfile | sort > $output
rm $tmpfile
echo "## CVE List convert success: $output"
```