### PR TITLE
distro: deby: Change Debian 10 (buster) repository to archive

### DIFF
--- a/conf/distro/deby.inc
+++ b/conf/distro/deby.inc
@@ -7,9 +7,11 @@ SDK_VERSION := "${DISTRO_VERSION}"
 MAINTAINER = "meta-debian Development Team"
 TARGET_VENDOR = "-deby"
 
+DEBIAN_MIRROR = "http://archive.debian.org/debian/pool"
+
 # Using the package versions provided in the security update mirror
 # is now necessary to pull updates by Debian LTS
-DEBIAN_SECURITY_UPDATE_MIRROR ?= "http://security.debian.org/debian-security/pool/updates"
+DEBIAN_SECURITY_UPDATE_MIRROR ?= "http://archive.debian.org/debian-security/pool/updates"
 
 # Extended LTS Updates for Debian 10 Buster
 DEBIAN_ELTS_SECURITY_UPDATE_MIRROR ?= "http://deb.freexian.com/extended-lts/pool"

--- a/doc/6.security-update.md
+++ b/doc/6.security-update.md
@@ -17,13 +17,7 @@ $ sudo apt-get install python3-debian
 
 ## Run test script
 
-You need to set TEST_ENABLE_SECURITY_UPDATE variable.
-
-```
-export TEST_ENABLE_SECURITY_UPDATE="1"
-```
-
-Also, you want to set other variables e.g. TEST_MACHINES, TEST_DISTROS, and so on.
+You want to set variables e.g. TEST_MACHINES, TEST_DISTROS, and so on.
 
 Then, you can build with docker.
 
@@ -34,25 +28,29 @@ $ make -C ../docker qemu_ptest
 
 # Build by yourself
 
-#### Enable security update repository
+## Enable security update repository
 
 Please set following lines in your conf/local.conf
 
 ```
 DEBIAN_SOURCE_ENABLED = "1"
 DEBIAN_SRC_FORCE_REGEN = "1"
-
 DEBIAN_SECURITY_UPDATE_ENABLED = "1"
-DEBIAN_SECURITY_UPDATE_MIRROR = "http://security.debian.org/debian-security/pool/updates"
-DEBIAN_ELTS_SECURITY_UPDATE_MIRROR = "http://deb.freexian.com/extended-lts/pool"
 ```
 
-DEBIAN_SECURITY_UPDATE_MIRROR specifies the LTS update repository.
-DEBIAN_ELTS_SECURITY_UPDATE_MIRROR specifies the ELTS update repository.
+Then, run bitbake command e.g. `bitbake -f core-image-minimal -c clean`.
 
-Then, run bitbake command e.g. bitbake -f core-image minimal -c clean.
+Note:
+  When `DEBIAN_SOURCE_ENABLED = "1"` the DEBIAN_MIRROR variable is used.
+  When `DEBIAN_SECURITY_UPDATE_ENABLED = "1"` the DEBIAN_SECURITY_UPDATE_MIRROR and the DEBIAN_ELTS_SECURITY_UPDATE_MIRROR variables are used.
 
-# Disable security update repository
+  Each variable is defined in conf/distro/deby.inc.
+  - DEBIAN_MIRROR: Debian 10 buster repository
+  - DEBIAN_SECURITY_UPDATE_MIRROR: The LTS update repository.
+  - DEBIAN_ELTS_SECURITY_UPDATE_MIRROR: The ELTS update repository.
+
+
+## Disable security update repository
 
 When all packages are uploaded to debian's main repository, and you don't need security update repository, you can disable security update repository.
 
@@ -61,6 +59,7 @@ Set following lines in your conf/local.conf, then run bitbake command.
 ```
 DEBIAN_SOURCE_ENABLED = "1"
 DEBIAN_SRC_FORCE_REGEN = "1"
+DEBIAN_SECURITY_UPDATE_ENABLED = "0"
 ```
 
 Before you run bitbake command, DEBIAN_SRC_URI uses DEBIAN_SECURITY_UPDATE_MIRROR as a debian mirror server.
@@ -91,11 +90,5 @@ After that, your can remove following lines from conf/local.conf.
 ```
 DEBIAN_SOURCE_ENABLED = "1"
 DEBIAN_SRC_FORCE_REGEN = "1"
-```
-
-Be careful, if package still use DEBIAN_SECURITY_UPDATE_MIRROR or DEBIAN_ELTS_SECURITY_UPDATE_MIRROR as a mirror server, you need following lines in your conf/local.conf to fetch source packages.
-
-```
-DEBIAN_SECURITY_UPDATE_MIRROR = "http://security.debian.org/debian-security/pool/updates"
-DEBIAN_ELTS_SECURITY_UPDATE_MIRROR = "http://deb.freexian.com/extended-lts/pool"
+DEBIAN_SECURITY_UPDATE_ENABLED = "0"
 ```

--- a/docker/common.yml
+++ b/docker/common.yml
@@ -18,7 +18,6 @@ services:
       TEST_DISTROS: ${TEST_DISTROS:-deby-tiny}
       TEST_MACHINES: ${TEST_MACHINES:-qemux86}
       TEST_DISTRO_FEATURES: ${TEST_DISTRO_FEATURES}
-      TEST_ENABLE_SECURITY_UPDATE: ${TEST_ENABLE_SECURITY_UPDATE}
     volumes:
       - ../:/home/deby/poky/meta-debian
       - downloads:/home/deby/downloads

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,7 +18,6 @@ Input params from env:
 | TEST_DISTROS         | Distros will be tested.         | "deby deby-tiny"          |
 | TEST_MACHINES        | Machines will be tested.        | "raspberrypi3 qemuarm"    |
 | TEST_DISTRO_FEATURES | DISTRO_FEATURES will be used.   | "pam x11"                 |
-| TEST_ENABLE_SECURITY_UPDATE | Enable security update repository. | "1"             |
 
 Example:
 ```sh

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -8,7 +8,6 @@
 #   TEST_DISTROS: distros will be tested. Eg: "deby deby-tiny"
 #   TEST_MACHINES: machines will be tested. Eg: "raspberrypi3 qemuarm"
 #   TEST_DISTRO_FEATURES: DISTRO_FEATURES will be used. Eg: "pam x11"
-#   TEST_ENABLE_SECURITY_UPDATE: If 1 is set, enable security update repository.
 
 trap "exit" INT
 
@@ -31,10 +30,6 @@ LAYER_DEPS_URL[beaglebone]="https://git.yoctoproject.org/git/meta-ti;branch=mast
 LAYER_DEPS_URL[raspberrypi3]="https://git.yoctoproject.org/git/meta-raspberrypi;branch=warrior"
 
 setup_builddir
-
-if [ "$TEST_ENABLE_SECURITY_UPDATE" = "1" ]; then
-	setup_security_update_repository
-fi
 
 if [ "$TEST_PACKAGES" = "" ]; then
 	TEST_PACKAGES_NOTSET=1

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -165,8 +165,3 @@ function get_all_packages {
 		rm -f $recipe_env
 	done
 }
-
-function setup_security_update_repository() {
-	set_var "DEBIAN_SECURITY_UPDATE_MIRROR" "http://security.debian.org/debian-security/pool/updates" conf/local.conf
-	set_var "DEBIAN_ELTS_SECURITY_UPDATE_MIRROR" "http://deb.freexian.com/extended-lts/pool" conf/local.conf
-}

--- a/tests/qemu_ptest.sh
+++ b/tests/qemu_ptest.sh
@@ -8,7 +8,6 @@
 #   TEST_PACKAGES: recipes/packages need to run ptest. Eg: "zlib quilt"
 #   TEST_MACHINES: machines will be tested. Eg: "qemux86 qemuarm"
 #   TEST_DISTRO_FEATURES: DISTRO_FEATURES will be used. Eg: "pam x11"
-#   TEST_ENABLE_SECURITY_UPDATE: If 1 is set, enable security update repository.
 #   PTEST_RUNNER_TIMEOUT: Timeout seconds for ptest-runner. Default: 300 seconds, Eg: 7200
 #   QEMU_PARAMS: Specify custom parameters to QEMU. Eg: "-smp 2 -m 2048"
 #     - `-smp`: Amount of CPU cores.
@@ -42,10 +41,6 @@ function scp_qemu {
 ssh-keygen -f "$HOME/.ssh/known_hosts" -R "[$TEST_IPADDR]:$TEST_PORT"
 
 setup_builddir
-
-if [ "$TEST_ENABLE_SECURITY_UPDATE" = "1" ]; then
-	setup_security_update_repository
-fi
 
 # Enable ptest
 append_var "DISTRO_FEATURES_append" " ptest" conf/local.conf


### PR DESCRIPTION
# Purpose of pull request

The Debian 10 (buster) repository moved to 'archive.debian.org'.

As a result, when updating packages, we cannot access the URLs defined in DEBIAN_MIRROR and DEBIAN_SECURITY_UPDATE_MIRROR [1].

So we change each variable definition as follows:

- DEBIAN_MIRROR:
  This variable is originally defined in poky/meta/conf/bitbake.conf.
  We add DEBIAN_MIRROR with the new URL 'archive.debian.org' to deby.inc.

- DEBIAN_SECURITY_UPDATE_MIRROR:
  We change the URL in this variable from 'security.debian.org' to 'archive.debian.org'.

**This PR is similar to solution 2-1 for `issue-no`, with the URL changed to ‘archive.debian.org’.**

And, remove to that TEST_ENABLE_SECURITY_UPDATE environment variable and related handling when run script of build_test or qemu_ptest in tests/, as it is now unnecessary.

Note:
---
[1] Steps to reproduce:

1. Add the following to local.conf
   ```
   DISTRO = "deby"
   MACHINE = "qemuarm64"
   DEBIAN_SOURCE_ENABLED = "1"
   DEBIAN_SRC_FORCE_REGEN = "1"
   DEBIAN_SECURITY_UPDATE_ENABLED = "1"
   ```

2. Run package update
   ```
   $ bitbake -f core-image-minimal -c clean
   ```
   
   Indicates that the old URLs are not accessible.
   ```
   WARNING: debian security update repository is enabled
   WARNING: debian ELTS security update repository is enabled
   Checking Debian Release ... http://deb.freexian.com/extended-lts/dists/buster-lts/Release
   Fetching Debian Sources.gz ... http://deb.freexian.com/extended-lts/dists/buster-lts/main/source/Sources.gz;md5sum=200c57e6f23b5d8d784c450c07be1b6b
   Parsing Debian Sources.gz ...
   Checking Debian Release ... http://security.debian.org/debian-security/dists/buster/updates/Release
   WARNING: Failed to check Debian Release. (HTTP Error 404: Not Found)
   Checking Debian Release ... http://ftp.debian.org/debian/dists/buster/Release
   WARNING: Failed to check Debian Release. (HTTP Error 404: Not Found)
   ```

# Test
## How to test

1. Setting local.conf

   Add following line into conf/local.conf.
   ```
   DISTRO = "deby"
   MACHINE = "qemuarm64"
   DEBIAN_SOURCE_ENABLED = "1"
   DEBIAN_SRC_FORCE_REGEN = "1"
   DEBIAN_SECURITY_UPDATE_ENABLED = "1"
   ```

2. Check for package updates

   Run the following command.
   ```
   build$ bitbake -f core-image-minimal -c clean
   ```

   If there are Debian's updates to the respective packages, the corresponding files in recipes-debian/sources/ will be updated.
   ```
   poky/meta-debian$ git status
   ```

3. Check build 

   Run the following command to build the core-image-minimal image.
   ```
   build$ bitbake core-image-minimal
   ```

4. Check bitbake variables

   Run the following command to check bitbake variables.
   ```
   build$ bitbake -e core-image-minimal | grep -B 10 -e '^DEBIAN_MIRROR=' -e '^DEBIAN_SECURITY_UPDATE_MIRROR=' -e '^DEBIAN_ELTS_SECURITY_UPDATE_MIRROR='
   ```

5. Check build_test script

   Run the following command to set environment variables.
   ```
   export TEST_PACKAGES="core-image-minimal"
   export TEST_DISTROS="deby"
   export TEST_MACHINES="qemuarm64"
   ```

   Run the following command in docker directory to check works build_test script.
   ```
   poky/meta-debian$ cd docker
   poky/meta-debian/docker $ make build_test
   ```


## Test result
### 2. Check for package updates

`archive.debian.org` is successfully accessed.
```
build$ bitbake -f core-image-minimal -c clean
WARNING: debian security update repository is enabled
WARNING: debian ELTS security update repository is enabled
Checking Debian Release ... http://deb.freexian.com/extended-lts/dists/buster-lts/Release
Fetching Debian Sources.gz ... http://deb.freexian.com/extended-lts/dists/buster-lts/main/source/Sources.gz;md5sum=66482ed088c9199eb23af2d8f6f4d32f
Parsing Debian Sources.gz ...
WARNING: Source code for package "curl" has been updated from "7.64.0-4+deb10u11" to "7.64.0-4+deb10u12"
WARNING: Source code for package "sudo" has been updated from "1.8.27-1+deb10u6" to "1.8.27-1+deb10u7"
WARNING: Source code for package "python2.7" has been updated from "2.7.16-2+deb10u5" to "2.7.16-2+deb10u6"
WARNING: Source code for package "u-boot" has been updated from "2019.01+dfsg-7" to "2019.01+dfsg-7+deb10u1"
Checking Debian Release ... http://archive.debian.org/debian-security/dists/buster/updates/Release
Fetching Debian Sources.gz ... http://archive.debian.org/debian-security/dists/buster/updates/main/source/Sources.gz;md5sum=e3bb28be0cf1fb769d3c63c037fc5bf8
Parsing Debian Sources.gz ...
Checking Debian Release ... http://archive.debian.org/debian/dists/buster/Release
Fetching Debian Sources.gz ... http://archive.debian.org/debian/dists/buster/main/source/Sources.gz;md5sum=60b1a2c60363095f2871f4a056e36980
Parsing Debian Sources.gz ...
Parsing recipes: 100% |##########################################################################################################################################################################################################################################| Time: 0:00:04
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 74 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "change-debian-repository-to-archive:c55d4d1aad2df8bc2ec503d4e1e598b6a14453a0"

Initialising tasks: 100% |#######################################################################################################################################################################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 1 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There were 6 WARNING messages shown.
```

Then, four packages detected updates.
```
poky/meta-debian$ git status
On branch change-debian-repository-to-archive
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   recipes-debian/sources/curl.inc
	modified:   recipes-debian/sources/python2.7.inc
	modified:   recipes-debian/sources/sudo.inc
	modified:   recipes-debian/sources/u-boot.inc

no changes added to commit (use "git add" and/or "git commit -a")
```

### 3. Check build 

The core-image-minimal image was successfully built.
```
build$ bitbake core-image-minimal 
Loading cache: 100% |############################################################################################################################################################################################################################################| Time: 0:00:00
Loaded 1822 entries from dependency cache.
WARNING: debian security update repository is enabled
WARNING: debian ELTS security update repository is enabled
Checking Debian Release ... http://deb.freexian.com/extended-lts/dists/buster-lts/Release
Fetching Debian Sources.gz ... http://deb.freexian.com/extended-lts/dists/buster-lts/main/source/Sources.gz;md5sum=66482ed088c9199eb23af2d8f6f4d32f
Parsing Debian Sources.gz ...
Checking Debian Release ... http://archive.debian.org/debian-security/dists/buster/updates/Release
Fetching Debian Sources.gz ... http://archive.debian.org/debian-security/dists/buster/updates/main/source/Sources.gz;md5sum=e3bb28be0cf1fb769d3c63c037fc5bf8
Parsing Debian Sources.gz ...
Checking Debian Release ... http://archive.debian.org/debian/dists/buster/Release
Fetching Debian Sources.gz ... http://archive.debian.org/debian/dists/buster/main/source/Sources.gz;md5sum=60b1a2c60363095f2871f4a056e36980
Parsing Debian Sources.gz ...
Parsing recipes: 100% |##########################################################################################################################################################################################################################################| Time: 0:00:01
Parsing of 1043 .bb files complete (1041 cached, 2 parsed). 1825 targets, 74 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "change-debian-repository-to-archive:c55d4d1aad2df8bc2ec503d4e1e598b6a14453a0"

Initialising tasks: 100% |#######################################################################################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 842 Found 0 Missed 842 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2965 tasks of which 5 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.
```

### 4. Check bitbake variables

The URL is defined to 'archive.debian.org' in meta-debian/conf/distro/deby.inc.
```
build$ bitbake -e core-image-minimal | grep -B 10 -e '^DEBIAN_MIRROR=' -e '^DEBIAN_SECURITY_UPDATE_MIRROR=' -e '^DEBIAN_ELTS_SECURITY_UPDATE_MIRROR='
DEBIANRDEP=""
#
# $DEBIAN_CODENAME
#   set? /home/deby/poky/meta-debian/classes/debian-source.bbclass:7
#     "${DISTRO_CODENAME}"
DEBIAN_CODENAME="buster"
#
# $DEBIAN_ELTS_SECURITY_UPDATE_MIRROR
#   set? /home/deby/poky/meta-debian/conf/distro/deby.inc:17
#     "http://deb.freexian.com/extended-lts/pool"
DEBIAN_ELTS_SECURITY_UPDATE_MIRROR="http://deb.freexian.com/extended-lts/pool"
#
# $DEBIAN_MIRROR [2 operations]
#   set /home/deby/poky/meta/conf/bitbake.conf:639
#     "http://ftp.debian.org/debian/pool"
#   set /home/deby/poky/meta-debian/conf/distro/deby.inc:10
#     "http://archive.debian.org/debian/pool"
# pre-expansion value:
#   "http://archive.debian.org/debian/pool"
DEBIAN_MIRROR="http://archive.debian.org/debian/pool"
--
#     "1"
#   set? /home/deby/poky/meta-debian/classes/debian-source.bbclass:10
#     "0"
# pre-expansion value:
#   "1"
DEBIAN_SECURITY_UPDATE_ENABLED="1"
#
# $DEBIAN_SECURITY_UPDATE_MIRROR
#   set? /home/deby/poky/meta-debian/conf/distro/deby.inc:14
#     "http://archive.debian.org/debian-security/pool/updates"
DEBIAN_SECURITY_UPDATE_MIRROR="http://archive.debian.org/debian-security/pool/updates"
```

### 5. Check build_test script

Confirmed build by the build_test script was successful.
```
poky/meta-debian/docker$ make build_test
docker-compose run --rm build_test
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
WARNING: The TEST_DISTRO_FEATURES variable is not set. Defaulting to a blank string.
Creating docker_build_test_run ... done
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
NOTE: These recipes will be tested: core-image-minimal
NOTE: Building core-image-minimal ...
NOTE: Build core-image-minimal: PASS
```